### PR TITLE
Add support for using MQTT server as a packet stream

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Set to any value to use MQTT instead of WebSocket
+# MQTT_ENABLE=true
+
+# MQTT connection settings
+MQTT_HOST=localhost
+MQTT_PORT=8083
+MQTT_TOPIC=meshcore/#
+
+# MQTT credentials (optional, leave empty for anonymous connections)
+MQTT_USERNAME=
+MQTT_PASSWORD=

--- a/App.tsx
+++ b/App.tsx
@@ -31,11 +31,11 @@ const App: React.FC = () => {
   const [isPaused, setIsPaused] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('connecting');
   const [isSimulation, setIsSimulation] = useState(false);
-  const [mqttBrokerUrl, setMqttBrokerUrl] = useState(`ws://${import.meta.env.MQTT_HOST || 'localhost'}:${import.meta.env.MQTT_PORT || '8083'}/mqtt`);
+  const [mqttBrokerUrl, setMqttBrokerUrl] = useState(import.meta.env.MQTT_URL || '');
   const [mqttTopic, setMqttTopic] = useState(import.meta.env.MQTT_TOPIC || 'meshcore/+/+/packets');
   const [showConnectionSettings, setShowConnectionSettings] = useState(false);
 
-  const isMqttEnabled = !!import.meta.env.MQTT_ENABLE;
+  const isMqttEnabled = !!import.meta.env.MQTT_URL;
 
   const streamServiceRef = useRef<StreamService | null>(null);
 
@@ -344,7 +344,7 @@ const App: React.FC = () => {
             value={mqttBrokerUrl}
             onChange={(e) => setMqttBrokerUrl(e.target.value)}
             className="flex-1 max-w-xs px-2 py-1 bg-slate-900 border border-slate-600 rounded text-sm text-slate-200 focus:outline-none focus:border-green-500"
-            placeholder="ws://broker:9001/mqtt"
+            placeholder="ws://broker:8083/mqtt"
           />
           <label className="text-xs text-slate-400">Topic:</label>
           <input
@@ -352,7 +352,7 @@ const App: React.FC = () => {
             value={mqttTopic}
             onChange={(e) => setMqttTopic(e.target.value)}
             className="flex-1 max-w-xs px-2 py-1 bg-slate-900 border border-slate-600 rounded text-sm text-slate-200 focus:outline-none focus:border-green-500"
-            placeholder="meshcore/+/packets"
+            placeholder="meshcore/+/+/packets"
           />
           <button
             onClick={handleMqttConfigSave}

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { Packet, DiscoveredNode } from './types';
-import { StreamService, ConnectionStatus } from './services/streamService';
+import { StreamService, ConnectionStatus, ConnectionMode } from './services/streamService';
 import { PacketList } from './components/PacketList';
 import { PacketDetails } from './components/PacketDetails';
 import { NodeList } from './components/NodeList';
@@ -16,7 +16,7 @@ type ViewMode = 'analyzer' | 'channels' | 'map';
 const App: React.FC = () => {
   const [packets, setPackets] = useState<Packet[]>([]);
   const [totalPacketCount, setTotalPacketCount] = useState(0);
-  
+
   // View State
   const [viewMode, setViewMode] = useState<ViewMode>('analyzer');
 
@@ -31,13 +31,18 @@ const App: React.FC = () => {
   const [isPaused, setIsPaused] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('connecting');
   const [isSimulation, setIsSimulation] = useState(false);
-  
+  const [mqttBrokerUrl, setMqttBrokerUrl] = useState(`ws://${import.meta.env.MQTT_HOST || 'localhost'}:${import.meta.env.MQTT_PORT || '8083'}/mqtt`);
+  const [mqttTopic, setMqttTopic] = useState(import.meta.env.MQTT_TOPIC || 'meshcore/+/+/packets');
+  const [showConnectionSettings, setShowConnectionSettings] = useState(false);
+
+  const isMqttEnabled = !!import.meta.env.MQTT_ENABLE;
+
   const streamServiceRef = useRef<StreamService | null>(null);
 
   useEffect(() => {
     // Initialize stream service
     streamServiceRef.current = new StreamService();
-    
+
     // Subscribe to Data
     const unsubscribeData = streamServiceRef.current.subscribe((packet) => {
       // 1. Packet Management
@@ -54,7 +59,7 @@ const App: React.FC = () => {
         setNodes((prevNodes) => {
           const newMap = new Map(prevNodes);
           const existing: DiscoveredNode | undefined = newMap.get(nodeInfo.id!);
-          
+
           newMap.set(nodeInfo.id!, {
             id: nodeInfo.id!,
             name: nodeInfo.name!,
@@ -98,22 +103,41 @@ const App: React.FC = () => {
     }
   };
 
+  const handleConnectionModeChange = (mode: ConnectionMode) => {
+    if (streamServiceRef.current) {
+      streamServiceRef.current.setConnectionMode(mode);
+      setIsPaused(false);
+    }
+  };
+
   const toggleSimulation = () => {
-      if (streamServiceRef.current) {
-          const newMode = !isSimulation;
-          setIsSimulation(newMode);
-          streamServiceRef.current.setSimulationMode(newMode);
-          // Reset paused state when switching modes usually feels better
-          setIsPaused(false); 
-          streamServiceRef.current.resume();
+    if (streamServiceRef.current) {
+      const newMode = !isSimulation;
+      setIsSimulation(newMode);
+      handleConnectionModeChange(newMode ? 'simulation' : (isMqttEnabled ? 'mqtt' : 'websocket'));
+    }
+  };
+
+  const handleMqttConfigSave = () => {
+    if (streamServiceRef.current) {
+      streamServiceRef.current.setMqttConfig({
+        brokerUrl: mqttBrokerUrl,
+        topicPattern: mqttTopic,
+      });
+      // Reconnect if currently in MQTT mode
+      if (isMqttEnabled && !isSimulation) {
+        streamServiceRef.current.stop();
+        streamServiceRef.current.start();
       }
+      setShowConnectionSettings(false);
+    }
   };
 
   const clearPackets = () => {
     setPackets([]);
     setTotalPacketCount(0);
     setSelectedPacket(null);
-    setNodes(new Map()); 
+    setNodes(new Map());
     // We don't necessarily clear channels derived from packets since packets are cleared
   };
 
@@ -140,17 +164,17 @@ const App: React.FC = () => {
           const info = p.decoded.group_text;
           const id = info.channel_name;
           const name = info.channel_name;
-          
+
           if (!channelMap.has(id)) {
-              channelMap.set(id, { 
-                  id, 
-                  name, 
-                  count: 0, 
-                  lastActivity: 0, 
-                  isEncrypted: false 
+              channelMap.set(id, {
+                  id,
+                  name,
+                  count: 0,
+                  lastActivity: 0,
+                  isEncrypted: false
               });
           }
-          
+
           const ch = channelMap.get(id)!;
           ch.count++;
           ch.lastActivity = Math.max(ch.lastActivity, p.ts);
@@ -161,9 +185,9 @@ const App: React.FC = () => {
   }, [packets]);
 
   // 2. Filtered Packets for Analyzer
-  const filteredPacketsAnalyzer = selectedNodeId 
+  const filteredPacketsAnalyzer = selectedNodeId
     ? packets.filter(p => {
-        return (p.decoded.group_text?.sender_name === selectedNodeId) || 
+        return (p.decoded.group_text?.sender_name === selectedNodeId) ||
                (p.decoded.advert?.appdata.node_name === selectedNodeId);
       })
     : packets;
@@ -190,9 +214,9 @@ const App: React.FC = () => {
   const getStatusIndicator = () => {
       if (isPaused) return { color: 'bg-yellow-500', text: 'Paused' };
       if (isSimulation) return { color: 'bg-purple-500', text: 'Simulation' };
-      
+
       switch (connectionStatus) {
-          case 'connected': return { color: 'bg-green-500 animate-pulse', text: 'Live' };
+          case 'connected': return { color: 'bg-green-500 animate-pulse', text: isMqttEnabled ? 'MQTT Live' : 'WS Live' };
           case 'connecting': return { color: 'bg-yellow-500', text: 'Connecting...' };
           case 'error': return { color: 'bg-red-500', text: 'Error' };
           default: return { color: 'bg-slate-500', text: 'Offline' };
@@ -207,7 +231,7 @@ const App: React.FC = () => {
       <header className="flex-none h-16 bg-slate-800 border-b border-slate-700 flex items-center justify-between px-6 shadow-md z-10 gap-4">
         {/* Logo and Status */}
         <div className="flex items-center gap-3 shrink-0">
-          <div className={`p-2 rounded-lg transition-colors ${isSimulation ? 'bg-purple-900/50' : 'bg-blue-600'}`}>
+          <div className={`p-2 rounded-lg transition-colors ${isSimulation ? 'bg-purple-900/50' : isMqttEnabled ? 'bg-green-600' : 'bg-blue-600'}`}>
             <Radio className={`w-6 h-6 ${isSimulation ? 'text-purple-400' : 'text-white'}`} />
           </div>
           <div className="mr-6">
@@ -220,21 +244,21 @@ const App: React.FC = () => {
 
           {/* View Switcher */}
           <div className="flex bg-slate-900/50 p-1 rounded-lg border border-slate-700">
-             <button 
+             <button
                 onClick={() => setViewMode('analyzer')}
                 className={`flex items-center gap-2 px-4 py-1.5 rounded-md text-sm font-medium transition-all ${viewMode === 'analyzer' ? 'bg-slate-700 text-white shadow-sm' : 'text-slate-400 hover:text-slate-200'}`}
              >
                 <Activity className="w-4 h-4" />
                 Packets
              </button>
-             <button 
+             <button
                 onClick={() => setViewMode('channels')}
                 className={`flex items-center gap-2 px-4 py-1.5 rounded-md text-sm font-medium transition-all ${viewMode === 'channels' ? 'bg-slate-700 text-white shadow-sm' : 'text-slate-400 hover:text-slate-200'}`}
              >
                 <MessageCircle className="w-4 h-4" />
                 Channels
              </button>
-             <button 
+             <button
                 onClick={() => setViewMode('map')}
                 className={`flex items-center gap-2 px-4 py-1.5 rounded-md text-sm font-medium transition-all ${viewMode === 'map' ? 'bg-slate-700 text-white shadow-sm' : 'text-slate-400 hover:text-slate-200'}`}
              >
@@ -263,14 +287,14 @@ const App: React.FC = () => {
         {/* Right Controls */}
         <div className="flex items-center gap-4 w-auto shrink-0 justify-end">
           <div className="flex gap-2">
-            
+
             {/* Simulation Toggle */}
             <button
               onClick={toggleSimulation}
               className={`
                 flex items-center gap-2 px-3 py-2 rounded-md transition-all border
-                ${isSimulation 
-                    ? 'bg-purple-900/30 border-purple-500/50 text-purple-300 hover:bg-purple-900/50' 
+                ${isSimulation
+                    ? 'bg-purple-900/30 border-purple-500/50 text-purple-300 hover:bg-purple-900/50'
                     : 'bg-slate-800 border-slate-700 text-slate-400 hover:text-white hover:bg-slate-700'
                 }
               `}
@@ -280,16 +304,27 @@ const App: React.FC = () => {
                 <span className="text-xs font-medium hidden sm:inline">{isSimulation ? 'Simulating' : 'Simulate'}</span>
             </button>
 
+            {/* MQTT Settings Button (visible when MQTT is enabled) */}
+            {isMqttEnabled && (
+              <button
+                onClick={() => setShowConnectionSettings(!showConnectionSettings)}
+                className="px-2.5 py-1.5 rounded-md text-xs font-medium bg-slate-800 border border-slate-700 text-slate-400 hover:text-white hover:bg-slate-700 transition-all"
+                title="MQTT Settings"
+              >
+                ⚙
+              </button>
+            )}
+
             <div className="w-px h-8 bg-slate-700 mx-2"></div>
 
-            <button 
+            <button
               onClick={togglePause}
               className={`p-2 rounded-md transition-colors ${isPaused ? 'bg-yellow-600/20 text-yellow-500 hover:bg-yellow-600/30' : 'bg-slate-700 hover:bg-slate-600 text-slate-200'}`}
               title={isPaused ? "Resume Stream" : "Pause Stream"}
             >
               {isPaused ? <Play className="w-5 h-5" /> : <Pause className="w-5 h-5" />}
             </button>
-            <button 
+            <button
               onClick={clearPackets}
               className="p-2 bg-slate-700 hover:bg-red-900/30 hover:text-red-400 text-slate-200 rounded-md transition-colors"
               title="Clear Buffer"
@@ -300,16 +335,44 @@ const App: React.FC = () => {
         </div>
       </header>
 
+      {/* MQTT Settings Panel */}
+      {showConnectionSettings && isMqttEnabled && (
+        <div className="flex-none bg-slate-800 border-b border-slate-700 px-6 py-3 flex items-center gap-4 z-10">
+          <label className="text-xs text-slate-400">Broker URL:</label>
+          <input
+            type="text"
+            value={mqttBrokerUrl}
+            onChange={(e) => setMqttBrokerUrl(e.target.value)}
+            className="flex-1 max-w-xs px-2 py-1 bg-slate-900 border border-slate-600 rounded text-sm text-slate-200 focus:outline-none focus:border-green-500"
+            placeholder="ws://broker:9001/mqtt"
+          />
+          <label className="text-xs text-slate-400">Topic:</label>
+          <input
+            type="text"
+            value={mqttTopic}
+            onChange={(e) => setMqttTopic(e.target.value)}
+            className="flex-1 max-w-xs px-2 py-1 bg-slate-900 border border-slate-600 rounded text-sm text-slate-200 focus:outline-none focus:border-green-500"
+            placeholder="meshcore/+/packets"
+          />
+          <button
+            onClick={handleMqttConfigSave}
+            className="px-3 py-1 bg-green-600 hover:bg-green-700 text-white rounded text-sm font-medium transition-colors"
+          >
+            Apply
+          </button>
+        </div>
+      )}
+
       {/* Main Content Grid */}
       <div className="flex-1 flex overflow-hidden relative">
-        
+
         {/* Column 1: Left Sidebar (Context sensitive) */}
         <div className="w-64 flex-none border-r border-slate-700 hidden md:flex flex-col bg-slate-900">
            {viewMode === 'analyzer' || viewMode === 'map' ? (
-               <NodeList 
-                 nodes={Array.from(nodes.values())} 
-                 selectedNodeId={selectedNodeId} 
-                 onSelectNode={handleNodeSelect} 
+               <NodeList
+                 nodes={Array.from(nodes.values())}
+                 selectedNodeId={selectedNodeId}
+                 onSelectNode={handleNodeSelect}
                />
            ) : (
                <ChannelList
@@ -322,7 +385,7 @@ const App: React.FC = () => {
 
         {/* Column 2: Main Content Area */}
         <div className="flex-1 flex flex-col min-w-0 bg-slate-900/50 relative">
-          
+
           {viewMode === 'analyzer' && (
             <>
               {selectedNodeId && (
@@ -332,9 +395,9 @@ const App: React.FC = () => {
                 </div>
               )}
               <div className="flex-1 relative min-h-0">
-                <PacketList 
-                  packets={filteredPacketsAnalyzer} 
-                  onSelect={handlePacketSelect} 
+                <PacketList
+                  packets={filteredPacketsAnalyzer}
+                  onSelect={handlePacketSelect}
                   selectedId={selectedPacket?.ts}
                 />
               </div>
@@ -343,7 +406,7 @@ const App: React.FC = () => {
 
           {viewMode === 'channels' && (
               selectedChannelId ? (
-                <ChannelChat 
+                <ChannelChat
                     packets={filteredPacketsChannel}
                     onSelectPacket={handlePacketSelect}
                     channelName={channels.find(c => c.id === selectedChannelId)?.name || selectedChannelId}
@@ -357,7 +420,7 @@ const App: React.FC = () => {
           )}
 
           {viewMode === 'map' && (
-             <NodeMap 
+             <NodeMap
                 nodes={Array.from(nodes.values())}
                 selectedNodeId={selectedNodeId}
                 onSelectNode={(id) => {
@@ -370,7 +433,7 @@ const App: React.FC = () => {
         </div>
 
         {/* Column 3: Details Panel */}
-        <div 
+        <div
           className={`
             flex-none bg-slate-800 flex flex-col transition-all duration-300 ease-in-out overflow-hidden
             ${isDetailsVisible ? 'w-[400px] border-l border-slate-700' : 'w-0 border-l-0'}
@@ -378,14 +441,14 @@ const App: React.FC = () => {
         >
           <div className="w-[400px] h-full flex flex-col">
             {showPacketDetails && selectedPacket ? (
-              <PacketDetails 
-                packet={selectedPacket} 
-                onClose={() => setSelectedPacket(null)} 
+              <PacketDetails
+                packet={selectedPacket}
+                onClose={() => setSelectedPacket(null)}
               />
             ) : showNodeDetails && selectedNodeId ? (
-               <NodeDetails 
-                  node={nodes.get(selectedNodeId)!} 
-                  packets={filteredPacketsAnalyzer} 
+               <NodeDetails
+                  node={nodes.get(selectedNodeId)!}
+                  packets={filteredPacketsAnalyzer}
                   onClose={() => setSelectedNodeId(null)}
                />
             ) : null}

--- a/README.md
+++ b/README.md
@@ -66,8 +66,20 @@ MQTT_PASSWORD=pass
 MQTT_TOPIC=meshcore/+/+/packets       # default value
 ```
 
+It should be noted that if the protocol used to access the YAMPA application
+uses TLS, then the connection to the MQTT server needs to also use TLS.
+This is a requirement enforced by TypeScript. If you attempt to mix TLS
+connections with non-TLS connections, then the MQTT connection will be
+denied by TypeScript and the MQTT connection will never succeed. If you
+are having troubles with the MQTT connection check the JavaScript console
+for error messages.
+
 The topic is set to receive packets sent with `meshcoretomqtt` script.
 `meshcoretomqtt` can be found at https://github.com/Cisien/meshcoretomqtt.
+Using the default topic pattern will allow packets to be read from all
+regions and all observers. If you desire to restrict what YAMPA can read,
+the first `+` represents the region code and the second `+` is the public
+key of each observer that is logging to the MQTT server.
 
 ## Frontend
 

--- a/README.md
+++ b/README.md
@@ -54,14 +54,13 @@ For devices flashed with **MeshCore USB Serial Companion** firmware (e.g. Heltec
 ## MQTT Server
 
 Connecting to a MQTT server requires that a number of variables be defined
-to specify the server and credentials to connect with. The topic to
-subscribe to is also specified with an environmental variable but it will
-default to `meshcore/+/+/packets` if not specified.
+to specify the server and credentials to connect with. The MQTT connection
+is enabled when MQTT_URL is specified otherwise the websocket packet stream
+is used. The topic to subscribe to is also specified with an environmental
+variable but it will default to `meshcore/+/+/packets` if not specified.
 
 ```shell
-MQTT_ENABLE=1
-MQTT_HOST=mqtt.server
-MQTT_PORT=8083                        # default value
+MQTT_URL=ws://broker:8083/mqtt
 MQTT_USERNAME=user
 MQTT_PASSWORD=pass
 MQTT_TOPIC=meshcore/+/+/packets       # default value

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This repository contains:
 - A React frontend UI.
 - A Python WebSocket server implementation in `server-pymc_core/`.
 
-The frontend expects a WebSocket endpoint that streams packet events as JSON.
+The frontend expects a WebSocket endpoint that streams packet events as JSON
+or a WebSocket stream from a MQTT server.
 
 ## Server (WebSocket packet stream)
 
@@ -49,6 +50,25 @@ For devices flashed with **MeshCore USB Serial Companion** firmware (e.g. Heltec
 | `--serial-port` | `/dev/ttyUSB0` | Serial port for the companion device |
 | `--host` | `localhost` | WebSocket server bind address |
 | `--port` | `8080` | WebSocket server port |
+
+## MQTT Server
+
+Connecting to a MQTT server requires that a number of variables be defined
+to specify the server and credentials to connect with. The topic to
+subscribe to is also specified with an environmental variable but it will
+default to `meshcore/+/+/packets` if not specified.
+
+```shell
+MQTT_ENABLE=1
+MQTT_HOST=mqtt.server
+MQTT_PORT=8083                        # default value
+MQTT_USERNAME=user
+MQTT_PASSWORD=pass
+MQTT_TOPIC=meshcore/+/+/packets       # default value
+```
+
+The topic is set to receive packets sent with `meshcoretomqtt` script.
+`meshcoretomqtt` can be found at https://github.com/Cisien/meshcoretomqtt.
 
 ## Frontend
 

--- a/components/PacketDetails.tsx
+++ b/components/PacketDetails.tsx
@@ -10,7 +10,7 @@ interface PacketDetailsProps {
 
 export const PacketDetails: React.FC<PacketDetailsProps> = ({ packet, onClose }) => {
   const date = new Date(packet.ts * 1000);
-  
+
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
   };
@@ -18,10 +18,10 @@ export const PacketDetails: React.FC<PacketDetailsProps> = ({ packet, onClose })
   // Helper to visualize path bytes
   const renderPathChain = (path: string) => {
     if (!path) return <span className="text-slate-500 italic">No routing path</span>;
-    
+
     // Split hex string into bytes (2 chars)
     const hops = path.match(/.{1,2}/g) || [];
-    
+
     return (
       <div className="flex flex-wrap gap-2 items-center mt-2">
         {hops.map((hop, index) => (
@@ -58,7 +58,7 @@ export const PacketDetails: React.FC<PacketDetailsProps> = ({ packet, onClose })
 
       {/* Content Scrollable */}
       <div className="flex-1 overflow-y-auto p-4 space-y-6">
-        
+
         {/* Meta Info */}
         <div className="grid grid-cols-2 gap-4">
           <div className="p-3 bg-slate-900/50 rounded-lg border border-slate-700">
@@ -155,7 +155,7 @@ export const PacketDetails: React.FC<PacketDetailsProps> = ({ packet, onClose })
                  <span>Type: {packet.packet.route_type_name}</span>
                  <span>Hops: {packet.routing.path_len}</span>
                </div>
-               
+
                {/* Visual Chain */}
                {renderPathChain(packet.routing.path)}
 
@@ -172,7 +172,7 @@ export const PacketDetails: React.FC<PacketDetailsProps> = ({ packet, onClose })
                 <Hash className="w-4 h-4 text-slate-400" />
                 Raw Packet
             </h3>
-            <button 
+            <button
               onClick={() => copyToClipboard(packet.raw_packet.hex)}
               className="p-1 hover:bg-slate-700 rounded text-slate-500 hover:text-white"
               title="Copy Hex"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "date-fns": "^4.1.0",
     "leaflet": "1.9.4",
     "lucide-react": "^0.563.0",
+    "mqtt": "^5.15.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "recharts": "^3.7.0"

--- a/services/mqttService.ts
+++ b/services/mqttService.ts
@@ -1,0 +1,169 @@
+import { Packet } from '../types';
+import { PacketDecoder, RawPacketData } from './packetDecoder';
+import mqtt, { MqttClient, IClientOptions } from 'mqtt';
+
+type PacketCallback = (packet: Packet) => void;
+type StatusCallback = (status: MqttConnectionStatus) => void;
+
+export type MqttConnectionStatus = 'connected' | 'disconnected' | 'connecting' | 'error';
+
+export interface MqttConfig {
+  brokerUrl: string;       // e.g., ws://broker:9001/mqtt
+  topicPattern: string;    // e.g., meshcore/+/packets
+  username?: string;
+  password?: string;
+}
+
+export class MqttService {
+  private client: MqttClient | null = null;
+  private callbacks: PacketCallback[] = [];
+  private statusCallbacks: StatusCallback[] = [];
+  private config: MqttConfig;
+  private isPaused: boolean = false;
+
+  constructor(config: MqttConfig) {
+    this.config = config;
+  }
+
+  public subscribe(callback: PacketCallback): () => void {
+    this.callbacks.push(callback);
+    return () => {
+      this.callbacks = this.callbacks.filter((cb) => cb !== callback);
+    };
+  }
+
+  public subscribeStatus(callback: StatusCallback): () => void {
+    this.statusCallbacks.push(callback);
+    callback(this.getCurrentStatus());
+    return () => {
+      this.statusCallbacks = this.statusCallbacks.filter((cb) => cb !== callback);
+    };
+  }
+
+  private emitStatus(status: MqttConnectionStatus) {
+    this.statusCallbacks.forEach(cb => cb(status));
+  }
+
+  private getCurrentStatus(): MqttConnectionStatus {
+    if (!this.client) return 'disconnected';
+    if (this.client.connected) return 'connected';
+    return 'connecting';
+  }
+
+  public updateConfig(config: MqttConfig) {
+    this.config = config;
+  }
+
+  public connect() {
+    if (this.client) return;
+    if (this.isPaused) return;
+
+    this.emitStatus('connecting');
+
+    const options: IClientOptions = {
+      reconnectPeriod: 3000,
+    };
+
+    if (this.config.username) {
+      options.username = this.config.username;
+    }
+    if (this.config.password) {
+      options.password = this.config.password;
+    }
+
+    this.client = mqtt.connect(this.config.brokerUrl, options);
+
+    this.client.on('connect', () => {
+      this.emitStatus('connected');
+      this.client?.subscribe(this.config.topicPattern, (err) => {
+        if (err) {
+          console.error('MQTT subscribe error:', err);
+        }
+      });
+    });
+
+    this.client.on('message', (_topic: string, payload: Buffer) => {
+      if (this.isPaused) return;
+      try {
+        const message = JSON.parse(payload.toString());
+        const rawData = this.transformToRawPacketData(message);
+        PacketDecoder.decodeRawPacket(rawData).then(decodedPacket => {
+          this.emit(decodedPacket);
+        });
+      } catch (e) {
+        console.error('Failed to parse MQTT message:', e);
+      }
+    });
+
+    this.client.on('error', (err) => {
+      console.error('MQTT error:', err);
+      this.emitStatus('error');
+    });
+
+    this.client.on('close', () => {
+      this.emitStatus('disconnected');
+    });
+
+    this.client.on('reconnect', () => {
+      this.emitStatus('connecting');
+    });
+  }
+
+  public disconnect() {
+    if (this.client) {
+      this.client.end(true);
+      this.client = null;
+    }
+    this.emitStatus('disconnected');
+  }
+
+  public pause() {
+    this.isPaused = true;
+    this.disconnect();
+  }
+
+  public resume() {
+    this.isPaused = false;
+    this.connect();
+  }
+
+  /**
+   * Transform MQTT payload to the RawPacketData format expected by PacketDecoder.
+   *
+   * MQTT payload example:
+   * {
+   *   "origin": "wt0f-observer",
+   *   "origin_id": "617CF109...",
+   *   "timestamp": "2026-06-25T21:29:16.300050",
+   *   "type": "PACKET",
+   *   "direction": "rx",
+   *   "raw": "1141277DFA30EA...",
+   *   "SNR": "12",
+   *   "RSSI": "-60"
+   * }
+   */
+  private transformToRawPacketData(message: any): RawPacketData {
+    // Parse ISO timestamp to epoch seconds
+    let ts: number;
+    if (message.timestamp) {
+      ts = new Date(message.timestamp).getTime() / 1000;
+    } else {
+      ts = Date.now() / 1000;
+    }
+
+    return {
+      ts,
+      raw_packet: {
+        hex: message.raw || '',
+      },
+      radio: {
+        rssi: message.RSSI ? parseInt(message.RSSI, 10) : 0,
+        snr: message.SNR ? parseInt(message.SNR, 10) : 0,
+      },
+    };
+  }
+
+  private emit(packet: Packet) {
+    this.callbacks.forEach((cb) => cb(packet));
+  }
+}

--- a/services/mqttService.ts
+++ b/services/mqttService.ts
@@ -9,7 +9,7 @@ export type MqttConnectionStatus = 'connected' | 'disconnected' | 'connecting' |
 
 export interface MqttConfig {
   brokerUrl: string;       // e.g., ws://broker:9001/mqtt
-  topicPattern: string;    // e.g., meshcore/+/packets
+  topicPattern: string;    // e.g., meshcore/+/+/packets
   username?: string;
   password?: string;
 }

--- a/services/packetDecoder.ts
+++ b/services/packetDecoder.ts
@@ -81,18 +81,18 @@ export class PacketDecoder {
    */
   public static async decodeRawPacket(rawData: RawPacketData): Promise<Packet> {
     const { raw_packet, radio = {}, routing = {}, ts } = rawData;
-    
+
     try {
       // Create key store with channel secrets for decryption
       const keyStore = MeshCorePacketDecoder.createKeyStore({
         channelSecrets: Object.values(this.CHANNELS).map(c => c.secret)
       });
-      
+
       // Decode the packet using meshcore-decoder with decryption
       const decoded = MeshCorePacketDecoder.decode(raw_packet.hex, {
         keyStore
       });
-      
+
       // Transform the decoded data to match our Packet interface
       return {
         ts,
@@ -112,8 +112,8 @@ export class PacketDecoder {
           snr: radio.snr || 0,
         },
         routing: {
-          path_len: decoded.pathLength,
-          path: decoded.path ? decoded.path.join('') : '',
+          path_len: decoded.pathLength || 0,
+          path: (decoded.pathLength > 0 && decoded.path) ? decoded.path.join('') : '',
         },
         payload: {
           hex: decoded.payload.raw,
@@ -122,7 +122,7 @@ export class PacketDecoder {
       };
     } catch (error) {
       console.error('Failed to decode packet:', error);
-      
+
       // Return a basic packet structure if decoding fails
       return {
         ts,
@@ -183,7 +183,7 @@ export class PacketDecoder {
         } else {
           channelName = await this.getChannelName(payload.channelHash);
         }
-        
+
         result.group_text = {
           decrypted: decrypted,
           channel_name: channelName,
@@ -258,7 +258,7 @@ export class PacketDecoder {
         channelName = Object.keys(this.CHANNELS)[index];
       }
     });
-    
+
     return channelName || ('Unknown ' + channelHash);
   }
 }

--- a/services/streamService.ts
+++ b/services/streamService.ts
@@ -26,14 +26,14 @@ export class StreamService {
   // MQTT state
   private mqttService: MqttService | null = null;
   private mqttConfig: MqttConfig = {
-    brokerUrl: `ws://${import.meta.env.MQTT_HOST || 'localhost'}:${import.meta.env.MQTT_PORT || '8083'}/mqtt`,
-    topicPattern: import.meta.env.MQTT_TOPIC || 'meshcore/#',
+    brokerUrl: import.meta.env.MQTT_URL,
+    topicPattern: import.meta.env.MQTT_TOPIC || 'meshcore/+/+/packets',
     username: import.meta.env.MQTT_USERNAME || undefined,
     password: import.meta.env.MQTT_PASSWORD || undefined,
   };
 
   // Mode — default to MQTT if MQTT_ENABLE is set
-  private connectionMode: ConnectionMode = import.meta.env.MQTT_ENABLE ? 'mqtt' : 'websocket';
+  private connectionMode: ConnectionMode = import.meta.env.MQTT_URL ? 'mqtt' : 'websocket';
 
   constructor() {
     this.parseMockData();
@@ -111,8 +111,10 @@ export class StreamService {
   public setSimulationMode(enabled: boolean) {
     if (enabled) {
       this.setConnectionMode('simulation');
-    } else {
+    } else if (this.connectionMode === 'websocket') {
       this.setConnectionMode('websocket');
+    } else if (this.connectionMode === 'mqtt') {
+      this.setConnectionMode('mqtt');
     }
   }
 

--- a/services/streamService.ts
+++ b/services/streamService.ts
@@ -1,25 +1,39 @@
 import { Packet } from '../types';
 import { MOCK_PACKET_DATA } from '../constants';
 import { PacketDecoder, RawPacketData } from './packetDecoder';
+import { MqttService, MqttConfig, MqttConnectionStatus } from './mqttService';
 
 type PacketCallback = (packet: Packet) => void;
 type StatusCallback = (status: ConnectionStatus) => void;
 
 export type ConnectionStatus = 'connected' | 'disconnected' | 'connecting' | 'error';
+export type ConnectionMode = 'websocket' | 'mqtt' | 'simulation';
 
 export class StreamService {
   private packets: RawPacketData[] = [];
   private callbacks: PacketCallback[] = [];
   private statusCallbacks: StatusCallback[] = [];
-  
+
   private intervalId: number | null = null;
   private currentIndex: number = 0;
   private isPaused: boolean = false;
-  
+
+  // WebSocket state
   private ws: WebSocket | null = null;
   private wsUrl: string = 'ws://192.168.178.93:8080/ws';
-  private isSimulationMode: boolean = false;
   private reconnectTimeoutId: number | null = null;
+
+  // MQTT state
+  private mqttService: MqttService | null = null;
+  private mqttConfig: MqttConfig = {
+    brokerUrl: `ws://${import.meta.env.MQTT_HOST || 'localhost'}:${import.meta.env.MQTT_PORT || '8083'}/mqtt`,
+    topicPattern: import.meta.env.MQTT_TOPIC || 'meshcore/#',
+    username: import.meta.env.MQTT_USERNAME || undefined,
+    password: import.meta.env.MQTT_PASSWORD || undefined,
+  };
+
+  // Mode — default to MQTT if MQTT_ENABLE is set
+  private connectionMode: ConnectionMode = import.meta.env.MQTT_ENABLE ? 'mqtt' : 'websocket';
 
   constructor() {
     this.parseMockData();
@@ -32,7 +46,6 @@ export class StreamService {
       .map((line) => {
         try {
           const fullPacket = JSON.parse(line);
-          // Extract only the raw packet data for client-side decoding
           return {
             ts: fullPacket.ts,
             raw_packet: fullPacket.raw_packet,
@@ -45,7 +58,7 @@ export class StreamService {
         }
       })
       .filter((p): p is RawPacketData => p !== null)
-      .sort((a, b) => a.ts - b.ts); 
+      .sort((a, b) => a.ts - b.ts);
   }
 
   public subscribe(callback: PacketCallback): () => void {
@@ -57,7 +70,6 @@ export class StreamService {
 
   public subscribeStatus(callback: StatusCallback): () => void {
     this.statusCallbacks.push(callback);
-    // Emit current status immediately
     callback(this.getCurrentStatus());
     return () => {
       this.statusCallbacks = this.statusCallbacks.filter((cb) => cb !== callback);
@@ -69,62 +81,131 @@ export class StreamService {
   }
 
   private getCurrentStatus(): ConnectionStatus {
-    if (this.isSimulationMode) return 'connected'; // Simulation is always "connected" (unless paused logic handled elsewhere, but simpler this way)
+    if (this.connectionMode === 'simulation') return 'connected';
+    if (this.connectionMode === 'mqtt') {
+      if (!this.mqttService) return 'disconnected';
+      return 'disconnected'; // Will be updated via MQTT status callback
+    }
     if (!this.ws) return 'disconnected';
     switch (this.ws.readyState) {
       case WebSocket.CONNECTING: return 'connecting';
       case WebSocket.OPEN: return 'connected';
-      case WebSocket.CLOSING: 
+      case WebSocket.CLOSING:
       case WebSocket.CLOSED: return 'disconnected';
       default: return 'disconnected';
     }
   }
 
+  public getConnectionMode(): ConnectionMode {
+    return this.connectionMode;
+  }
+
+  public setConnectionMode(mode: ConnectionMode) {
+    if (this.connectionMode === mode) return;
+    this.stop();
+    this.connectionMode = mode;
+    this.start();
+  }
+
+  // Legacy method for backward compatibility
   public setSimulationMode(enabled: boolean) {
-    if (this.isSimulationMode === enabled) return;
-    
-    this.stop(); // Stop current mode
-    this.isSimulationMode = enabled;
-    this.start(); // Start new mode
+    if (enabled) {
+      this.setConnectionMode('simulation');
+    } else {
+      this.setConnectionMode('websocket');
+    }
+  }
+
+  public setWsUrl(url: string) {
+    this.wsUrl = url;
+  }
+
+  public setMqttConfig(config: Partial<MqttConfig>) {
+    this.mqttConfig = { ...this.mqttConfig, ...config };
+    if (this.mqttService) {
+      this.mqttService.updateConfig(this.mqttConfig);
+    }
+  }
+
+  public getMqttConfig(): MqttConfig {
+    return { ...this.mqttConfig };
   }
 
   public start() {
-    if (this.isSimulationMode) {
-      this.startSimulation();
-    } else {
-      this.connectWebSocket();
+    switch (this.connectionMode) {
+      case 'simulation':
+        this.startSimulation();
+        break;
+      case 'mqtt':
+        this.connectMqtt();
+        break;
+      case 'websocket':
+      default:
+        this.connectWebSocket();
+        break;
     }
   }
 
   public stop() {
     this.stopSimulation();
     this.closeWebSocket();
+    this.disconnectMqtt();
   }
 
   public pause() {
     this.isPaused = true;
-    // When paused, we stop the connection/simulation to prevent updates and attempts
-    if (this.isSimulationMode) {
-      this.stopSimulation();
-    } else {
-      this.closeWebSocket();
+    switch (this.connectionMode) {
+      case 'simulation':
+        this.stopSimulation();
+        break;
+      case 'mqtt':
+        this.mqttService?.pause();
+        break;
+      case 'websocket':
+        this.closeWebSocket();
+        break;
     }
   }
 
   public resume() {
     this.isPaused = false;
-    // When resuming, we restart the connection/simulation
     this.start();
+  }
+
+  // --- MQTT Logic ---
+
+  private connectMqtt() {
+    if (this.mqttService) return;
+    if (this.isPaused) return;
+
+    this.mqttService = new MqttService(this.mqttConfig);
+
+    this.mqttService.subscribe((packet) => {
+      this.emit(packet);
+    });
+
+    this.mqttService.subscribeStatus((status: MqttConnectionStatus) => {
+      this.emitStatus(status);
+    });
+
+    this.mqttService.connect();
+  }
+
+  private disconnectMqtt() {
+    if (this.mqttService) {
+      this.mqttService.disconnect();
+      this.mqttService = null;
+    }
   }
 
   // --- WebSocket Logic ---
 
   private connectWebSocket() {
     if (this.ws) return;
-    if (this.isPaused) return; // Do not connect if paused
+    if (this.isPaused) return;
 
     this.emitStatus('connecting');
-    
+
     try {
         this.ws = new WebSocket(this.wsUrl);
 
@@ -151,9 +232,8 @@ export class StreamService {
         this.ws.onclose = () => {
             this.emitStatus('disconnected');
             this.ws = null;
-            
-            // Only reconnect if not in simulation mode AND NOT PAUSED
-            if (!this.isSimulationMode && !this.isPaused) {
+
+            if (this.connectionMode === 'websocket' && !this.isPaused) {
                 this.reconnectTimeoutId = window.setTimeout(() => this.connectWebSocket(), 3000);
             }
         };
@@ -161,13 +241,12 @@ export class StreamService {
         this.ws.onerror = (err) => {
             console.error('WebSocket error:', err);
             this.emitStatus('error');
-            // ws.close() will be called automatically or manually, triggering onclose
         };
 
     } catch (e) {
         console.error("Connection failed immediately", e);
         this.emitStatus('error');
-        if (!this.isSimulationMode && !this.isPaused) {
+        if (this.connectionMode === 'websocket' && !this.isPaused) {
             this.reconnectTimeoutId = window.setTimeout(() => this.connectWebSocket(), 3000);
         }
     }
@@ -179,13 +258,11 @@ export class StreamService {
         this.reconnectTimeoutId = null;
     }
     if (this.ws) {
-      this.ws.onclose = null; // Prevent reconnect trigger during manual close
+      this.ws.onclose = null;
       this.ws.close();
       this.ws = null;
     }
-    // Only emit disconnected if we aren't switching modes immediately 
-    // (though in pause context we generally want to emit disconnected)
-    if (!this.isSimulationMode) {
+    if (this.connectionMode === 'websocket') {
         this.emitStatus('disconnected');
     }
   }
@@ -196,26 +273,21 @@ export class StreamService {
     if (this.intervalId) return;
     if (this.isPaused) return;
 
-    this.emitStatus('connected'); 
+    this.emitStatus('connected');
 
     this.intervalId = window.setInterval(() => {
-      // Logic inside here just emits; pause check handled by interval clearing in this.pause()
       if (this.currentIndex >= this.packets.length) {
-        this.currentIndex = 0; // Loop forever
+        this.currentIndex = 0;
       }
 
       const rawPacket = this.packets[this.currentIndex];
-      
-      // We clone the packet and update the timestamp to now 
-      // so it feels like a live stream in the UI
       const liveRawPacket = { ...rawPacket, ts: Date.now() / 1000 };
-      
-      // Decode the raw packet using the client-side decoder
+
       PacketDecoder.decodeRawPacket(liveRawPacket).then(decodedPacket => {
         this.emit(decodedPacket);
       });
       this.currentIndex++;
-    }, 1000); 
+    }, 1000);
   }
 
   private stopSimulation() {

--- a/utils.ts
+++ b/utils.ts
@@ -8,7 +8,7 @@ export const formatPath = (path: string): string => {
 
 export const extractNodeFromPacket = (packet: Packet): Partial<DiscoveredNode> | null => {
   const { decoded, ts, radio } = packet;
-  
+
   // Case 1: Advert Packet (Rich info)
   if (decoded.advert && decoded.advert.appdata.node_name) {
     return {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(({ mode }) => {
       server: {
         port: 3000,
         host: '0.0.0.0',
+        allowedHosts: true,
       },
       plugins: [react()],
       define: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      envPrefix: ['VITE_', 'MQTT_'],
       server: {
         port: 3000,
         host: '0.0.0.0',


### PR DESCRIPTION
This PR expands YAMPA to source packets from an MQTT server. Switching between the MQTT connection and the websocket connection is accomplished by specifying the MQTT_URL environmental variable. Currently only websocket MQTT connections are supported. 

