### PR TITLE
Bump meshcodedecoder to 0.3.0, fixed multi-byte paths

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -225,7 +225,7 @@ const App: React.FC = () => {
                 className={`flex items-center gap-2 px-4 py-1.5 rounded-md text-sm font-medium transition-all ${viewMode === 'analyzer' ? 'bg-slate-700 text-white shadow-sm' : 'text-slate-400 hover:text-slate-200'}`}
              >
                 <Activity className="w-4 h-4" />
-                Analyzer
+                Packets
              </button>
              <button 
                 onClick={() => setViewMode('channels')}

--- a/components/PacketDetails.tsx
+++ b/components/PacketDetails.tsx
@@ -10,18 +10,22 @@ interface PacketDetailsProps {
 
 export const PacketDetails: React.FC<PacketDetailsProps> = ({ packet, onClose }) => {
   const date = new Date(packet.ts * 1000);
-  
+
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
   };
 
   // Helper to visualize path bytes
-  const renderPathChain = (path: string) => {
+  const renderPathChain = (path: string, pathHashSize: number) => {
     if (!path) return <span className="text-slate-500 italic">No routing path</span>;
-    
-    // Split hex string into bytes (2 chars)
-    const hops = path.match(/.{1,2}/g) || [];
-    
+
+    // Split hex string into hops of pathHashSize bytes (2 chars per byte)
+    const bytesPerHop = pathHashSize * 2;
+    const hops: string[] = [];
+    for (let i = 0; i < path.length; i += bytesPerHop) {
+      hops.push(path.slice(i, i + bytesPerHop));
+    }
+
     return (
       <div className="flex flex-wrap gap-2 items-center mt-2">
         {hops.map((hop, index) => (
@@ -58,7 +62,7 @@ export const PacketDetails: React.FC<PacketDetailsProps> = ({ packet, onClose })
 
       {/* Content Scrollable */}
       <div className="flex-1 overflow-y-auto p-4 space-y-6">
-        
+
         {/* Meta Info */}
         <div className="grid grid-cols-2 gap-4">
           <div className="p-3 bg-slate-900/50 rounded-lg border border-slate-700">
@@ -153,11 +157,11 @@ export const PacketDetails: React.FC<PacketDetailsProps> = ({ packet, onClose })
              <div className="bg-slate-900 rounded-lg p-3 border border-slate-700">
                <div className="flex justify-between text-xs text-slate-500 mb-2">
                  <span>Type: {packet.packet.route_type_name}</span>
-                 <span>Hops: {packet.routing.path_len}</span>
+                 <span>Hops: {packet.routing.path_len} × {packet.routing.path_hash_size} bytes</span>
                </div>
-               
+
                {/* Visual Chain */}
-               {renderPathChain(packet.routing.path)}
+               {renderPathChain(packet.routing.path, packet.routing.path_hash_size)}
 
                <div className="mt-4 font-mono text-[10px] text-slate-500 break-all bg-black/20 p-2 rounded">
                  Raw: {packet.routing.path}
@@ -172,7 +176,7 @@ export const PacketDetails: React.FC<PacketDetailsProps> = ({ packet, onClose })
                 <Hash className="w-4 h-4 text-slate-400" />
                 Raw Packet
             </h3>
-            <button 
+            <button
               onClick={() => copyToClipboard(packet.raw_packet.hex)}
               className="p-1 hover:bg-slate-700 rounded text-slate-500 hover:text-white"
               title="Copy Hex"

--- a/components/PacketRow.tsx
+++ b/components/PacketRow.tsx
@@ -63,7 +63,7 @@ export const PacketRow: React.FC<PacketRowProps> = ({ packet, onClick, isSelecte
        return <span className="text-slate-500 font-mono text-xs">{packet.payload.hex.substring(0, 16)}...</span>
     }
     // Updated to use formatPath
-    return <span className="text-slate-500 font-mono text-xs" title={formatPath(packet.routing.path)}>{formatPath(packet.routing.path)}</span>;
+    return <span className="text-slate-500 font-mono text-xs" title={formatPath(packet.routing.path, packet.routing.path_hash_size)}>{formatPath(packet.routing.path, packet.routing.path_hash_size)}</span>;
   };
 
   return (

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@michaelhart/meshcore-decoder": "^0.1.9",
+    "@michaelhart/meshcore-decoder": "^0.3.0",
     "date-fns": "^4.1.0",
     "leaflet": "1.9.4",
     "lucide-react": "^0.563.0",

--- a/services/packetDecoder.ts
+++ b/services/packetDecoder.ts
@@ -81,18 +81,18 @@ export class PacketDecoder {
    */
   public static async decodeRawPacket(rawData: RawPacketData): Promise<Packet> {
     const { raw_packet, radio = {}, routing = {}, ts } = rawData;
-    
+
     try {
       // Create key store with channel secrets for decryption
       const keyStore = MeshCorePacketDecoder.createKeyStore({
         channelSecrets: Object.values(this.CHANNELS).map(c => c.secret)
       });
-      
+
       // Decode the packet using meshcore-decoder with decryption
       const decoded = MeshCorePacketDecoder.decode(raw_packet.hex, {
         keyStore
       });
-      
+
       // Transform the decoded data to match our Packet interface
       return {
         ts,
@@ -112,8 +112,9 @@ export class PacketDecoder {
           snr: radio.snr || 0,
         },
         routing: {
-          path_len: decoded.pathLength,
-          path: decoded.path ? decoded.path.join('') : '',
+          path_len: decoded.pathLength || 0,
+          path_hash_size: decoded.pathHashSize || 1,
+          path: (decoded.pathLength > 0 && decoded.path) ? decoded.path.join('') : '',
         },
         payload: {
           hex: decoded.payload.raw,
@@ -122,7 +123,7 @@ export class PacketDecoder {
       };
     } catch (error) {
       console.error('Failed to decode packet:', error);
-      
+
       // Return a basic packet structure if decoding fails
       return {
         ts,
@@ -183,7 +184,7 @@ export class PacketDecoder {
         } else {
           channelName = await this.getChannelName(payload.channelHash);
         }
-        
+
         result.group_text = {
           decrypted: decrypted,
           channel_name: channelName,
@@ -258,7 +259,7 @@ export class PacketDecoder {
         channelName = Object.keys(this.CHANNELS)[index];
       }
     });
-    
+
     return channelName || ('Unknown ' + channelHash);
   }
 }

--- a/types.ts
+++ b/types.ts
@@ -20,6 +20,7 @@ export interface RadioStats {
 
 export interface RoutingInfo {
   path_len: number;
+  path_hash_size: number;
   path: string;
 }
 

--- a/utils.ts
+++ b/utils.ts
@@ -1,9 +1,13 @@
 import { Packet, DiscoveredNode } from './types';
 
-export const formatPath = (path: string): string => {
+export const formatPath = (path: string, pathHashSize: number = 1): string => {
   if (!path) return '';
-  // Split into 2-character chunks (bytes)
-  return path.match(/.{1,2}/g)?.join(' → ') || path;
+  const bytesPerHop = pathHashSize * 2;
+  const hops: string[] = [];
+  for (let i = 0; i < path.length; i += bytesPerHop) {
+    hops.push(path.slice(i, i + bytesPerHop));
+  }
+  return hops.join(' → ');
 };
 
 export const extractNodeFromPacket = (packet: Packet): Partial<DiscoveredNode> | null => {


### PR DESCRIPTION
This PR adds support to properly decoding multi-byte paths. Without this change multi-byte packets will decode as "RawCustom" packets and the entire packet gets decoded as the path. 